### PR TITLE
Added fix "detected dubious ownership"

### DIFF
--- a/dockerfiles/ruby-2.7.8+rails.Dockerfile
+++ b/dockerfiles/ruby-2.7.8+rails.Dockerfile
@@ -49,4 +49,7 @@ RUN /usr/local/bundle/bin/rails _7.0.6_ new rails7-psql   --minimal -d postgresq
 RUN /usr/local/bundle/bin/rails _7.0.6_ new rails7-mysql  --minimal -d mysql
 RUN /usr/local/bundle/bin/rails _7.0.6_ new rails7-sqlite --minimal -d sqlite3
 
+RUN git config --global --add safe.directory /home/the_role_dev/the_role_api
+RUN git config --global --add safe.directory /home/the_role_dev/to_slug_param
+
 WORKDIR /home/the_role_dev


### PR DESCRIPTION
When typing ```ruby dev/test``` i got that warnings

![image](https://github.com/TheRole/the_role_dev/assets/34093966/0543e242-f999-4da1-9845-555d0094a049)

so i think we need to include these commands in dockerfile to fix that.